### PR TITLE
Ignore README.md in build pipeline

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -3,6 +3,8 @@ name: Build and Deploy React App to CloudFront
 on:
   push:
     branches: [main]
+    paths-ignore: ["README.md"]
+
 jobs:
   build-and-deploy:
     name: Build and Deploy


### PR DESCRIPTION
Changes:
- adds a configuration to the workflow to ignore the README.md file
- prevents builds from happening if README.md was the only file that got updated